### PR TITLE
fix: update environment configurations for transparency and image

### DIFF
--- a/src/app/domain/transparency/components/transparency-accordion/transparency-accordion.html
+++ b/src/app/domain/transparency/components/transparency-accordion/transparency-accordion.html
@@ -19,7 +19,7 @@
     @if (content?.type === accordionContentType.DOCUMENT) {
       <section class="py-4">
         @for (item of content?.documents; track $index) {
-          <a [href]="item.url" target="_blank" class="flex items-center gap-2 py-2">
+          <a [href]="item.url" rel="noopener noreferrer" target="_blank" class="flex items-center gap-2 py-2">
             <p class="text-lg font-semibold">{{ item.name }}</p>
             <mat-icon fontSet="material-symbols-rounded">download</mat-icon>
           </a>

--- a/src/app/domain/transparency/services/transparency-service.ts
+++ b/src/app/domain/transparency/services/transparency-service.ts
@@ -23,7 +23,7 @@ export class TransparencyService {
             : AccordionContentType.DOCUMENT,
           documents: category.documents?.map((doc) => ({
             name: doc.title,
-            url: doc.previewLink,
+            url: `${environment.bucketUrl}${doc.previewLink}`
           })),
           collaborators: category.collaborators?.map((collab) => ({
             imageUrl: collab.previewLink,

--- a/src/app/shared/services/image-service.ts
+++ b/src/app/shared/services/image-service.ts
@@ -6,7 +6,7 @@ import { environment } from '../../../environments/environment';
 })
 export class ImageService {
 
-  private readonly BUCKET_URL = `${environment.bucketUrl}/`;
+  private readonly BUCKET_URL = `${environment.bucketUrl}/pub/`;
 
   getImageUrl(key: string): string {
     return this.BUCKET_URL + key;

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiUrl: 'https://api-dev.apollomusic.com.br/api',
-  bucketUrl: 'https://files.apollomusic.com.br/oficinadasmeninasteste/pub'
+  bucketUrl: 'https://files.apollomusic.com.br/oficinadasmeninasteste'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'https://api-dev.apollomusic.com.br/api',
-  bucketUrl: 'https://files.apollomusic.com.br/oficinadasmeninasteste/pub'
+  apiUrl: 'https://api.apollomusic.com.br/api',
+  bucketUrl: 'https://files.apollomusic.com.br/oficinadasmeninasteste'
 };


### PR DESCRIPTION
This pull request updates how document and image URLs are constructed and improves security for document links. The main changes include standardizing the use of the `bucketUrl` environment variable, updating production and development environment configurations, and enhancing link security in the transparency accordion component.

**Environment configuration updates:**

* Updated `bucketUrl` in both `environment.ts` and `environment.development.ts` to remove the `/pub` suffix, and changed the production `apiUrl` to the correct endpoint. [[1]](diffhunk://#diff-d897f7d114ca657c43905bff9a6ee17e53e2d1ccc172b7c258a54183653a691aL3-R4) [[2]](diffhunk://#diff-a8781811a71ccc5e6e8919aa7054cf3a9c66d8624b4687cb9029aa12a5b93049L4-R4)

**URL construction changes:**

* Modified the `TransparencyService` to build document URLs by concatenating `environment.bucketUrl` with `doc.previewLink`, ensuring consistent URL formation for documents.
* Adjusted the `ImageService` to append `/pub/` to `environment.bucketUrl` internally, centralizing the logic for image URL creation.

**Security improvement:**

* Added `rel="noopener noreferrer"` to document download links in the transparency accordion component for safer external navigation.