### PR TITLE
fix: adicionando alt de  algumas imagens e ajustando o carousel

### DIFF
--- a/src/app/domain/home/containers/home/home.ts
+++ b/src/app/domain/home/containers/home/home.ts
@@ -25,8 +25,8 @@ import { SupportCard } from '../../components/support-card/support-card';
   styleUrl: './home.scss',
 })
 export class Home {
-  eventImages$: Observable<string[]> | null = null;
-  partnerImages$: Observable<string[]> | null = null;
+  eventImages$: Observable<{ path: string, alt: string }[]> | null = null;
+  partnerImages$: Observable<{ path: string, alt: string }[]> | null = null;
 
   yearOfFoundation = new Date('03-23-2002').getFullYear();
   today = new Date().getFullYear();
@@ -37,12 +37,18 @@ export class Home {
   ngOnInit() {
     this.eventImages$ = this.eventService
       .list()
-      .pipe(map((events) => events.data.map((event) => event.previewImageUrl)));
+      .pipe(map((events) => events.data.map((event) => ({
+        path: event.previewImageUrl,
+        alt: "Evento " + event.title
+      }))));
 
     this.partnerImages$ = this.partnerService
       .list()
       .pipe(
-        map((partners) => partners.data.map((partner) => partner.previewImageUrl))
+        map((partners) => partners.data.map((partner) => ({
+          path: partner.previewImageUrl,
+          alt: "Logo " + partner.name
+        })))
       );
   }
 }

--- a/src/app/shared/components/carousel/carousel.html
+++ b/src/app/shared/components/carousel/carousel.html
@@ -13,9 +13,9 @@
     <swiper-slide class="flex justify-center items-center">
       <div [class]="slideClass" [style]="'--carousel-aspect-ratio: ' + aspectRatio">
         <img
-          [src]="slide"
+          [src]="slide.path"
           [class]="imgClass"
-          alt="Imagem do carrossel"
+          [alt]="slide.alt"
         />
       </div>
     </swiper-slide>

--- a/src/app/shared/components/carousel/carousel.ts
+++ b/src/app/shared/components/carousel/carousel.ts
@@ -9,13 +9,13 @@ register();
   templateUrl: './carousel.html',
   styleUrls: ['./carousel.scss'],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
 })
 export class CarouselComponent {
-  @Input() slides!: string[];
+  @Input() slides!: { path: string; alt: string }[];
   @Input() slideClass: string = '';
   @Input() imgClass: string = '';
-  @Input() slidesPerView: number | 'auto' = 'auto';
+  @Input() slidesPerView: number = 0;
   @Input() spaceBetween: number = 30;
   @Input() autoplayDelay: number = 5000;
   @Input() aspectRatio: string = '16 / 10';
@@ -33,17 +33,17 @@ export class CarouselComponent {
     const width = window.innerWidth;
     const slideCount = this.slides.length;
 
-    if (width < 768 ) {
+    if (width < 768) {
       this.slidesPerView = 1;
     }
 
-    for (const breakpoint of this.breakpoints) {
-      if (width > breakpoint.width && slideCount > breakpoint.slides) {
-        this.slidesPerView = breakpoint.slidesPerView;
-        break;
+    if (this.slidesPerView === 0) {
+      for (const breakpoint of this.breakpoints) {
+        if (width > breakpoint.width && slideCount > breakpoint.slides) {
+          this.slidesPerView = breakpoint.slidesPerView;
+          break;
+        }
       }
     }
-
-
   }
 }


### PR DESCRIPTION
**Image Data Structure and Accessibility Improvements:**

* The `eventImages and `partnerImages observables in `home.ts` now emit arrays of objects with `path` and `alt` properties instead of just image URLs, allowing for descriptive alt text for each image. [[1]](diffhunk://#diff-5cdd572eb813093b1730d7e13e3f5cbcb6039f4d96cfde26da363b88443ed88eL28-R29) [[2]](diffhunk://#diff-5cdd572eb813093b1730d7e13e3f5cbcb6039f4d96cfde26da363b88443ed88eL40-R51)
* The `CarouselComponent`'s `slides` input is updated to accept an array of `{ path: string; alt: string }` objects, enabling each carousel image to have a specific alt text.
* The carousel template (`carousel.html`) now binds to `slide.path` for the image source and `slide.alt` for the alt attribute, improving accessibility for screen readers.

**Carousel Behavior Adjustments:**

* The `slidesPerView` input in `CarouselComponent` is changed from `number | 'auto'` to just `number`, with logic added to dynamically set the number of slides per view based on breakpoints when the value is zero. [[1]](diffhunk://#diff-bc116ba78622bfbe8c6ca84be5b147ef5f8082c5237a1437e498fe8205ede66eL12-R18) [[2]](diffhunk://#diff-bc116ba78622bfbe8c6ca84be5b147ef5f8082c5237a1437e498fe8205ede66eR40-R47)