### PR TITLE
fix: ajuste de classes e tamanhos de imagens em componentes

### DIFF
--- a/src/app/domain/events/components/event-card/event-card.html
+++ b/src/app/domain/events/components/event-card/event-card.html
@@ -4,7 +4,7 @@
   [routerLink]="['/eventos', eventId]"
   (click)="onCardClick()"
   >
-  <img [src]="imageUrl" class="h-full object-cover" [alt]="eventTitle" />
+  <img [src]="imageUrl" class="h-full w-full object-cover" [alt]="eventTitle" />
   <div class="absolute inset-0 z-10 bg-gradient-to-t from-black"></div>
   <div class="absolute inset-x-0 bottom-0 z-20 p-4">
     <p class="mb-1 text-sm text-gray-300 w-fit">

--- a/src/app/domain/events/containers/event-details/event-details.html
+++ b/src/app/domain/events/containers/event-details/event-details.html
@@ -55,16 +55,16 @@
                   'float-none ' +
                   'mx-auto ' +
                   'w-full ' +
-                  'max-w-160 ' +
+                  'max-w-140 ' +
                   'lg:max-w-max ' +
                   'lg:aspect-[16/10] ' +
                   'lg:w-auto'
                 "
           [text]="'Imagem do evento ' + event()?.title" />
       }
-      <div class="max-w-180">
+      <div class="max-w-140">
         <img
-          class="h-96 object-cover lg:mr-5 rounded-xl lg:float-left float-none mx-auto hover:scale-105 transition-transform duration-300"
+          class="h-96 w-full object-cover lg:mr-5 rounded-xl lg:float-left float-none mx-auto hover:scale-105 transition-transform duration-300"
           [class.hidden]="!previewImageLoaded()"
           src="{{ event()?.previewImageUrl }}"
           alt="Imagem do evento {{ event()?.title }}"
@@ -78,17 +78,19 @@
 
 @if (event()?.partnersImageUrl) {
 <section class="w-full flex flex-col pl-4 pr-4 lg:pl-20 lg:pr-20 pb-10 pt-8 bg-gray-100">
-  <div class="w-full text-center">
+  <div class="w-full text-center ">
     <h2 class="text-2xl lg:text-4xl font-bold mb-8 text-gray-800">Parceiros</h2>
     @if (!partnersImageLoaded()) {
     <app-skeleton-image [imageCss]="'w-full max-w-250 mx-auto aspect-[16/9]'" [text]="'Parceiros e apoiadores do evento ' + event()?.title" />
     }
-    <img
-      class="w-250 rounded-xl object-contain mx-auto hover:scale-105 transition-transform duration-300"
+    <div class="max-w-250 mx-auto">
+      <img
+      class="rounded-xl w-250 h-150 object-contain mx-auto hover:scale-105 transition-transform duration-300"
       [class.hidden]="!partnersImageLoaded()"
       src="{{ event()?.partnersImageUrl }}"
       alt="Parceiros e apoiadores do evento {{ event()?.title }}"
       (load)="onPartnersImageLoad()" />
+    </div>
   </div>
 </section>
 }

--- a/src/app/domain/home/containers/home/home.html
+++ b/src/app/domain/home/containers/home/home.html
@@ -111,7 +111,7 @@
       [slides]="eventImages"
       [spaceBetween]="20"
       [aspectRatio]="'16 / 10'"
-      slideClass="bg-white p-2 rounded-xl shadow-lg border-2 border-white w-full"
+      slideClass="bg-white p-2 rounded-xl shadow-lg border-2 border-white w-full max-w-md"
       imgClass="object-cover rounded-md size-full"
     />
     }
@@ -171,7 +171,7 @@
     [spaceBetween]="25"
     [slidesPerView]="3"
     slideClass="flex justify-center items-center h-30 md:h-36 w-full hover:scale-105 transition-transform duration-300"
-    imgClass="!object-contain w-auto h-full"
+    imgClass="!object-contain w-auto h-full max-w-[20rem]"
   />
   }
 </section>

--- a/src/app/shared/components/carousel/carousel.html
+++ b/src/app/shared/components/carousel/carousel.html
@@ -3,13 +3,14 @@
   [attr.autoplay-delay]="autoplayDelay"
   [attr.space-between]="spaceBetween"
   grab-cursor="true"
-  mousewheel="true"
+  initial-slide="0"
+  mousewheel="false"
   keyboard="true"
   autoplay-disable-on-interaction="false"
   autoplay-pause-on-mouse-enter="true"
   class="w-full">
   @for (slide of slides; track $index) {
-  <swiper-slide class="flex justify-center items-center flex-col">
+  <swiper-slide class="flex justify-center items-center flex-col w-auto">
     <div [class]="slideClass" [style]="'--carousel-aspect-ratio: ' + aspectRatio">
       <img [src]="slide.path" [class]="imgClass" [alt]="slide.alt" />
     </div>

--- a/src/app/shared/components/carousel/carousel.ts
+++ b/src/app/shared/components/carousel/carousel.ts
@@ -15,6 +15,7 @@ export class CarouselComponent {
   @Input() slides!: { path: string; alt: string }[];
   @Input() withTitle: boolean = false;
   @Input() slideClass: string = '';
+  @Input() swiperSlideClass: string = '';
   @Input() imgClass: string = '';
   @Input() slidesPerView: number = 0;
   @Input() spaceBetween: number = 30;


### PR DESCRIPTION
This pull request focuses on improving the visual consistency and layout of event-related images and carousels across the application. The main changes include adjustments to image sizing, container widths, and carousel configuration to ensure images are displayed correctly and responsively in different contexts.

**Image and layout adjustments:**

* Updated the event card image in `event-card.html` to use both full height and width for better coverage and alignment.
* Modified the event details image containers and images in `event-details.html` to use consistent `max-w-140` and `w-full` classes, improving responsiveness and alignment on different devices.
* Enhanced the partners section in `event-details.html` by wrapping the image in a container and setting explicit width and height for better layout control.

**Carousel improvements:**

* Adjusted carousel slide classes in `home.html` to set a maximum width for event slides and images, ensuring consistent sizing and preventing oversized images. [[1]](diffhunk://#diff-a49ad69af5a749bb746e7ce6288f010cdef08489a5ee4e797ab79265817e5661L114-R114) [[2]](diffhunk://#diff-a49ad69af5a749bb746e7ce6288f010cdef08489a5ee4e797ab79265817e5661L174-R174)
* Updated carousel configuration in `carousel.html` to disable mousewheel navigation, set the initial slide, and add width constraints to swiper slides for improved user experience and layout consistency.
* Added a new `swiperSlideClass` input to the `CarouselComponent` in `carousel.ts` to allow more flexible styling of individual carousel slides.